### PR TITLE
Add min_tokens param to openai frontend and through to trt backend.

### DIFF
--- a/llgtrt/src/routes/completions.rs
+++ b/llgtrt/src/routes/completions.rs
@@ -101,6 +101,7 @@ fn req_params_from_openai(params: &CommonCreateParams) -> Result<RequestParams> 
         frequency_penalty: params.frequency_penalty,
         presence_penalty: params.presence_penalty,
         logprobs: params.logprobs.unwrap_or(0) > 0,
+        min_tokens: params.min_tokens as u32,
         ..Default::default()
     };
 

--- a/llgtrt/src/routes/openai.rs
+++ b/llgtrt/src/routes/openai.rs
@@ -99,6 +99,10 @@ pub struct CommonCreateParams {
     /// model generates is valid JSON.
     pub response_format: Option<ResponseFormat>,
 
+    /// The minimum number of tokens to generate in the completion.
+    #[serde(default = "default_min_tokens")]
+    pub min_tokens: usize,
+
     #[serde(default)]
     pub llg_log_level: LlgLogLevel,
 
@@ -156,6 +160,10 @@ fn default_temperature() -> f32 {
 
 fn default_top_p() -> f32 {
     1.0
+}
+
+fn default_min_tokens() -> usize {
+    1
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/scripts/test-infer.sh
+++ b/scripts/test-infer.sh
@@ -51,6 +51,27 @@ curl -X POST "${TRT_API_BASE}chat/completions" \
 }' | jq
 ;;
 
+  chat_min_tokens)
+curl -X POST "${TRT_API_BASE}chat/completions" \
+-H "Content-Type: application/json" \
+-d '{
+  "model": "model",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful assistant."
+    },
+    {
+      "role": "user",
+      "content": "Please tell me a one line joke."
+    }
+  ],
+  "max_tokens": 100,
+  "min_tokens": 100,
+  "temperature": 1.2
+}' | jq
+;;
+
   json)
 curl -v -X POST "${TRT_API_BASE}chat/completions" \
 -H "Content-Type: application/json" \

--- a/trtllm-c/main.cpp
+++ b/trtllm-c/main.cpp
@@ -154,6 +154,8 @@ TlcStatus tlc_enqueue_request(TlcExecutor* ctx, TlcRequest const* request, TlcRe
             samplingConfig.setSeed(p.seed);
         if (p.top_k != 0)
             samplingConfig.setTopK(p.top_k);
+        if (p.min_tokens != 0)
+            samplingConfig.setMinTokens(p.min_tokens);
 
         tle::VecTokens tokens(request->tokens, request->tokens + request->num_tokens);
         tle::Request req(std::move(tokens), p.max_new_tokens, p.streaming, samplingConfig, outputConfig);

--- a/trtllm-c/tlc.h
+++ b/trtllm-c/tlc.h
@@ -1,9 +1,9 @@
 #ifndef TLC_H
 #define TLC_H
 
-#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -97,6 +97,7 @@ extern "C"
         float frequency_penalty;
         float presence_penalty;
         uint32_t top_k;
+        uint32_t min_tokens;
         uint64_t seed;
     } TlcRequestParams;
 

--- a/trtllm_rs/src/tlc.rs
+++ b/trtllm_rs/src/tlc.rs
@@ -56,6 +56,7 @@ impl Default for RequestParams {
             presence_penalty: 0.0,
             frequency_penalty: 0.0,
             top_k: 0,
+            min_tokens: 1,
             eos_token_id: u32::MAX,
             seed: u64::MAX,
             use_logits_post_processor: false,


### PR DESCRIPTION
Useful for benchmarking throughput, since one can force a specific number of output tokens.