### PR TITLE
Adds LoRA support including cache warmup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,15 +120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,12 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,17 +595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
@@ -808,7 +782,7 @@ dependencies = [
  "log",
  "nu-ansi-term",
  "regex",
- "thiserror 1.0.64",
+ "thiserror",
 ]
 
 [[package]]
@@ -952,16 +926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "half"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,7 +974,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror 1.0.64",
+ "thiserror",
  "ureq",
 ]
 
@@ -1498,15 +1462,12 @@ dependencies = [
  "clap",
  "flexi_logger",
  "futures-core",
- "half",
  "json5",
  "llguidance",
  "log",
  "memmap2",
  "minijinja",
  "minijinja-contrib",
- "ndarray",
- "ndarray-npy",
  "rand",
  "rayon",
  "safetensors",
@@ -1552,12 +1513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lockfree-object-pool"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,16 +1539,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
 
 [[package]]
 name = "memchr"
@@ -1707,35 +1652,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray-npy"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b313788c468c49141a9d9b6131fc15f403e6ef4e8446a0b2e18f664ddb278a9"
-dependencies = [
- "byteorder",
- "ndarray",
- "num-complex",
- "num-traits",
- "py_literal",
- "zip",
 ]
 
 [[package]]
@@ -1977,7 +1893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror 1.0.64",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -2060,15 +1976,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,19 +2001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "py_literal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-traits",
- "pest",
- "pest_derive",
 ]
 
 [[package]]
@@ -2147,12 +2041,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -2202,7 +2090,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.64",
+ "thiserror",
 ]
 
 [[package]]
@@ -2545,12 +2433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,16 +2549,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl 1.0.64",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2684,17 +2557,6 @@ name = "thiserror-impl"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2753,7 +2615,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 1.0.64",
+ "thiserror",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -2916,9 +2778,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bindgen",
- "half",
  "libc",
- "ndarray",
  "safetensors",
  "serde",
 ]
@@ -3482,35 +3342,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zip"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "crossbeam-utils",
- "displaydoc",
- "flate2",
- "indexmap 2.6.0",
- "memchr",
- "thiserror 2.0.11",
- "zopfli",
-]
-
-[[package]]
-name = "zopfli"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "lockfree-object-pool",
- "log",
- "once_cell",
- "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +564,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +610,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -782,7 +808,7 @@ dependencies = [
  "log",
  "nu-ansi-term",
  "regex",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -926,6 +952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,7 +1010,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "ureq",
 ]
 
@@ -1462,11 +1498,14 @@ dependencies = [
  "clap",
  "flexi_logger",
  "futures-core",
+ "half",
  "json5",
  "llguidance",
  "log",
  "minijinja",
  "minijinja-contrib",
+ "ndarray",
+ "ndarray-npy",
  "rand",
  "rayon",
  "serde",
@@ -1511,6 +1550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1582,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "memchr"
@@ -1641,6 +1696,35 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray-npy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b313788c468c49141a9d9b6131fc15f403e6ef4e8446a0b2e18f664ddb278a9"
+dependencies = [
+ "byteorder",
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "py_literal",
+ "zip",
 ]
 
 [[package]]
@@ -1882,7 +1966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.64",
  "ucd-trie",
 ]
 
@@ -1965,6 +2049,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,11 +2078,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "py_literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "pest",
+ "pest_derive",
 ]
 
 [[package]]
@@ -2030,6 +2136,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -2079,7 +2191,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2412,6 +2524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,9 +2592,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2528,7 +2646,16 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.64",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2536,6 +2663,17 @@ name = "thiserror-impl"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2594,7 +2732,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 1.0.64",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -2757,7 +2895,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bindgen",
+ "half",
  "libc",
+ "ndarray",
  "serde",
 ]
 
@@ -3320,4 +3460,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.6.0",
+ "memchr",
+ "thiserror 2.0.11",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,12 +1502,14 @@ dependencies = [
  "json5",
  "llguidance",
  "log",
+ "memmap2",
  "minijinja",
  "minijinja-contrib",
  "ndarray",
  "ndarray-npy",
  "rand",
  "rayon",
+ "safetensors",
  "serde",
  "serde_json",
  "tokio",
@@ -1598,6 +1600,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memo-map"
@@ -2390,6 +2401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "safetensors"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0436dbfa2778e4ec1a00801b0ae24a1dd619499247d48b0589b679103379d0d4"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,6 +2919,7 @@ dependencies = [
  "half",
  "libc",
  "ndarray",
+ "safetensors",
  "serde",
 ]
 

--- a/LoRA.md
+++ b/LoRA.md
@@ -1,0 +1,123 @@
+# LoRA support in llgtrt
+
+TensorRT provides full support for parameter-efficient finetuning via a technicque called _Low Rank Adaptation_, commonly abbreviated as _LoRA_.  The engine even provides support for multiple simultaneous sets of finetuned weights (often known as _Multi-LoRA_), though configuring this requires a few extra steps, both during setup and inference.
+
+The following extra steps are required during setup:
+
+1. Compile the base model weights with the LoRA module activated.
+2. Convert each set of LoRA weights from standard Huggingface format to a specialized tensor format compatible with TensorRT.  Store these in a directory accessible from your TensorRT installation.
+3. Launch llgtrt/TensorRT with an extra parameter pointing to your LoRA weights.
+
+During inference, TensorRT maintains a cache of LoRA weights within GPU memory where the precise number of LoRA models that can fit in the cache varies based on your configuration.  To perform inference using a specific LoRA model you must first load its weights into the cache keyed by a unique integer identifier.  Once weights are loaded then subsequent inference requests may be made using the integer Id alone.  Depending on the size of your cache, loading a new set of LoRA weights may result in another set being evicted from the cache.
+
+## Setup details
+
+Detailed instructions on how to prepare a llgtrt/TensorRT instance for LoRA:
+
+### Compiling the base model
+
+From within the llgtrt Docker container, use _convert_checkpoint.py_ as you normally would but then add additional LoRA-specific parameters when calling _trtllm-build_:
+
+```bash
+# Convert the HF model to a checkpoint
+python3 /opt/TensorRT-LLM-examples/llama/convert_checkpoint.py \
+    --dtype bfloat16 \
+    --model_dir /models/Meta-Llama-3.1-8B-Instruct \
+    --output_dir /models/model-ckpt \
+    --tp_size 1
+
+# Run trtllm build with LoRA enabled.  For this example we activate the attn_q, attn_k, and attn_v modules.
+trtllm-build --checkpoint_dir /models/model-ckpt \
+    --gemm_plugin bfloat16 \
+    --output_dir /models/model-engine \
+    --use_paged_context_fmha enable \
+    --lora_plugin bfloat16 \
+    --lora_dir /models/My-Finetuned-Meta-Llama-3.1-8B-Instruct \
+    --lora_ckpt_source hf \
+    --lora_target_modules attn_q attn_k attn_v
+
+# Clean up checkpoint (optional)
+rm -rf /models/model-ckpt
+
+# Finally, copy tokenizer.json and tokenizer_config.json
+cp /models/Meta-Llama-3.1-8B-Instruct/tokenizer.json /models/model-engine
+cp /models/Meta-Llama-3.1-8B-Instruct/tokenizer_config.json /models/model-engine
+
+# Exit the container
+exit
+```
+
+### Converting LoRA weights
+
+TensorRT cannot read LoRA weights directly from Huggingface safetensors format. So we convert weights to a simplified "tensor" format that TensorRT can read.  Note that these weights are simply converted -- unlike the base model they are not compiled into an execution graph.  TensorRT provides the _hf_lora_convert.py_ utility to perform this conversion.  This step should be done within the llgtrt container.
+
+```bash
+# Create a directory for LoRA weights
+mkdir -p /models/lora/my_finetuning
+
+# Convert weights.  Float32 is used only as an intemediate storage type here; the weights will be converted to bfloat16 when loaded for inference.
+python3 /code/TensorRT-LLM/examples/hf_lora_convert.py -i /models/My-Finetuned-Meta-Llama-3.1-8B-Instruct -o /models/lora/my_finetuning --storage-type float32
+
+exit
+```
+
+### Launching llgtrt with LoRA
+
+When launching llgtrt you must specify the root directory for your various finetuned models as an additional
+parameter.
+
+```bash
+PORT=3001 ./docker/run.sh /models/Meta-Llama-3.1-8B-Instruct models/lora
+```
+
+## Inference
+
+To load a set of LoRA weights into the TensorRT cache, specify _lora_id_ and _lora_dir_ in your inference request:
+
+``` json
+{
+    "model": "llama",
+    "messages": [
+        {
+            "role": "user",
+            "content": "What is the meaning of life?"
+        }
+    ],
+    "lora_id": 17,
+    "lora_dir": "my_finetuning"
+}
+```
+
+Once a set of LoRA weights is loaded, subsequent requests may done using _lora_id_ alone:
+
+``` json
+{
+    "model": "llama",
+    "messages": [
+        {
+            "role": "user",
+            "content": "What is the meaning of life?"
+        }
+    ],
+    "lora_id": 17
+}
+```
+
+Finally, you may continue to run base model (non-finetuned) inference requests by omitting both LoRA parameters:
+
+``` json
+{
+    "model": "llama",
+    "messages": [
+        {
+            "role": "user",
+            "content": "What is the meaning of life?"
+        }
+    ],
+}
+```
+
+There is no need to restart llgtrt or the TensorRT engine to load a new set of LoRA weights into the cache; weights can be loaded on-the-fly as needed.
+
+
+LoRA support in llgtrt based on this [nVidia example](https://developer.nvidia.com/blog/tune-and-deploy-lora-llms-with-nvidia-tensorrt-llm/).

--- a/LoRA.md
+++ b/LoRA.md
@@ -4,11 +4,13 @@ TensorRT provides full support for parameter-efficient finetuning via a technicq
 
 The following extra steps are required during setup:
 
-1. Compile the base model weights with the LoRA module activated.
-2. Convert each set of LoRA weights from standard Huggingface format to a specialized tensor format compatible with TensorRT.  Store these in a directory accessible from your TensorRT installation.
+1. Build the base model engine with the LoRA module activated.
+2. Extract each set of LoRA weights from standard Huggingface format to a specialized tensor format compatible with TensorRT.  Store these in a directory accessible from your TensorRT installation.
 3. Launch llgtrt/TensorRT with an extra parameter pointing to your LoRA weights.
 
-During inference, TensorRT maintains a cache of LoRA weights within GPU memory where the precise number of LoRA models that can fit in the cache varies based on your configuration.  To perform inference using a specific LoRA model you must first load its weights into the cache keyed by a unique integer identifier.  Once weights are loaded then subsequent inference requests may be made using the integer Id alone.  Depending on the size of your cache, loading a new set of LoRA weights may result in another set being evicted from the cache.
+During inference, TensorRT maintains a cache of LoRA weights within GPU memory where the precise number of LoRA models that can fit in the cache varies based on your configuration.  To perform inference using a specific LoRA model TensorRT must first load its weights into the cache, which will happen automatically as needed.  Once weights are loaded then subsequent inference requests will be made without needing to load weights.  Depending on the size of your cache, loading a new set of LoRA weights may result in another set being evicted from the cache.
+(for those familiar with TensorRT: internally TensorRT uses an integer Id to represent a loaded set of weights.  Llgtrt manages these Ids for you, obviating the need to
+refer to them directly)
 
 ## Setup details
 

--- a/LoRA.md
+++ b/LoRA.md
@@ -51,7 +51,7 @@ exit
 
 ### Extract LoRA weights
 
-TensorRT cannot read LoRA weights directly from Huggingface safetensors format. So we provide a Python-based utility to extract weights into a simplified "tensor" format that TensorRT can read.
+TensorRT cannot read LoRA weights directly from Huggingface safetensors format. So we provide a Python-based utility to extract weights into a simplified format (also safetensors-based) that TensorRT can read.  More specifically, the generated .safetensors file contains two tensors: "weights" (containing the actual LoRA weights) and "config" (containing a tensor representation of the LoRA layers affected).
 Note that these weights are simply converted -- unlike the base model they are not compiled into an execution graph.
 The scripts/extrct_lora.py utility performs the extraction.  It should be run within the llgtrt container.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ Drop the following `llgtrt.json5` file in engine folder:
 }
 ```
 
+## LoRA and Multi-LoRA
+
+Support for finetuned models via LoRA is provided but requires a few extra steps.
+Detailed instructions are in [LoRA.md](LoRA.md)
+
 ## Development
 
 First, build the Docker container to be used in the dev container. If you have already followed the steps above, you can skip this. Otherwise, run `./docker/build.sh`.
@@ -147,7 +152,7 @@ The basic structure of the server borrows inspiration from [npuichigo/openai_trt
 
 ## TODO
 
-- [ ] multi-LoRA?
+- [X] multi-LoRA
 - [x] test phi-3.5
 - [ ] multi-modal input
 - [ ] when streaming, and stop is set, we need to buffer the output so as not to return the stop sequence itself

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -24,9 +24,11 @@ else
     exit 1
 fi
 
-ora_volume=''
+lora_volume=''
+lora_arg=''
 if [ ! -z "$LORADIR" ]; then
     lora_volume="--volume $LORADIR:/lora"
+    lora_arg="--lora-root /lora"
 fi
 
 set -e
@@ -39,4 +41,5 @@ cd $(dirname $0)/..
     /usr/local/bin/launch-llgtrt.sh \
         /engine \
         --port $PORT \
+        ${lora_arg} \
         "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,10 +5,15 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$1" ]; then
-    echo "Usage: $0 /path/to/engine"
+    echo "Usage: $0 /path/to/engine [/path/to/lora/weights]"
     exit 1
 else
     ENGINE="$1"
+    shift
+fi
+
+if [ ! -z "$1" ]; then
+    LORADIR="$1"
     shift
 fi
 
@@ -19,10 +24,16 @@ else
     exit 1
 fi
 
+ora_volume=''
+if [ ! -z "$LORADIR" ]; then
+    lora_volume="--volume $LORADIR:/lora"
+fi
+
 set -e
 cd $(dirname $0)/..
 ./docker/drun.sh \
     --volume "$ENGINE":/engine \
+    ${lora_volume} \
     --publish $PORT:$PORT \
     llgtrt/llgtrt:latest \
     /usr/local/bin/launch-llgtrt.sh \

--- a/llgtrt/Cargo.toml
+++ b/llgtrt/Cargo.toml
@@ -25,8 +25,5 @@ minijinja = { version = "2.3.1", features = ["preserve_order", "loop_controls", 
 chrono = "0.4.38"
 json5 = "0.4.1"
 minijinja-contrib = { version = "2.3.1", features = ["pycompat"] }
-ndarray = "0.16.1"
-ndarray-npy = "0.9.1"
-half = "2.4.1"
 safetensors = "0.5.2"
 memmap2 = "0.9.5"

--- a/llgtrt/Cargo.toml
+++ b/llgtrt/Cargo.toml
@@ -25,3 +25,6 @@ minijinja = { version = "2.3.1", features = ["preserve_order", "loop_controls", 
 chrono = "0.4.38"
 json5 = "0.4.1"
 minijinja-contrib = { version = "2.3.1", features = ["pycompat"] }
+ndarray = "0.16.1"
+ndarray-npy = "0.9.1"
+half = "2.4.1"

--- a/llgtrt/Cargo.toml
+++ b/llgtrt/Cargo.toml
@@ -28,3 +28,5 @@ minijinja-contrib = { version = "2.3.1", features = ["pycompat"] }
 ndarray = "0.16.1"
 ndarray-npy = "0.9.1"
 half = "2.4.1"
+safetensors = "0.5.2"
+memmap2 = "0.9.5"

--- a/llgtrt/src/async_exec.rs
+++ b/llgtrt/src/async_exec.rs
@@ -425,7 +425,7 @@ impl AsyncExecutor {
 
     pub fn add_request(
         &mut self,
-        init: RequestInit,
+        init: &RequestInit,
         llgs: Vec<Box<Constraint>>,
     ) -> Result<(ReqId, UnboundedReceiver<StepResults>)> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();

--- a/llgtrt/src/config.rs
+++ b/llgtrt/src/config.rs
@@ -145,6 +145,10 @@ pub struct CliConfig {
     #[arg(long, help_heading = CONFIG_OPTIONS)]
     pub chat_template: Option<String>,
 
+    /// Root directory for LoRA weights; defaults to None (LoRA disabled)
+    #[arg(long, help_heading = CONFIG_OPTIONS)]
+    pub lora_root: Option<String>,
+
     /// Print the merged configuration and exit
     #[arg(long, help_heading = CONFIG_OPTIONS)]
     pub print_config: bool,

--- a/llgtrt/src/error.rs
+++ b/llgtrt/src/error.rs
@@ -4,9 +4,17 @@ use axum::{
     Json,
 };
 use serde_json::json;
+use std::fmt;
 
 #[derive(Debug)]
 pub struct AppError(anyhow::Error);
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Delegate to the `Display` implementation of `anyhow::Error`
+        write!(f, "{}", self.0)
+    }
+}
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {

--- a/llgtrt/src/lib.rs
+++ b/llgtrt/src/lib.rs
@@ -8,3 +8,4 @@ pub mod state;
 mod async_exec;
 pub mod logging;
 pub mod jsonutil;
+pub mod lora;

--- a/llgtrt/src/lora.rs
+++ b/llgtrt/src/lora.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+struct LoraCacheInternal {
+    id_map: HashMap<String, u64>,
+    max_id: u64,
+}
+
+pub struct LoraCache {
+    inner: Mutex<LoraCacheInternal>,
+}
+
+impl LoraCache {
+    pub fn new() -> Self {
+        let inner = LoraCacheInternal {
+            id_map: HashMap::new(),
+            max_id: 1,
+        };
+        LoraCache {
+            inner: Mutex::new(inner),
+        }
+    }
+
+    /// Returns the unsigned integer Id to use for a given lora directory string, finding one if necessary.
+    pub fn resolve_id(&self, lora_dir: &str) -> u64 {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(id) = inner.id_map.get(lora_dir) {
+            *id
+        } else {
+            inner.max_id += 1;
+            let lora_id = inner.max_id;
+            inner.id_map.insert(lora_dir.to_string(), lora_id);
+            lora_id
+        }
+    }
+}

--- a/llgtrt/src/routes/completions.rs
+++ b/llgtrt/src/routes/completions.rs
@@ -385,6 +385,16 @@ async fn mk_req_info(
         req_params.temperature = 1.0;
 
         req_params.use_logits_post_processor = true;
+
+        // If we do that, we need to make sure we return the tokens forced
+        // by the grammar to the user. Currently we don't have infra for that,
+        // so instead we just start the parser without the prompt.
+        //
+        // if is_chat {
+        //     tokens.extend_from_slice(&llg.process_prompt(vec![]));
+        // } else {
+        //     tokens = llg.process_prompt(tokens);
+        // }
         llg.start_without_prompt();
 
         let mut r = vec![Box::new(llg)];

--- a/llgtrt/src/routes/openai.rs
+++ b/llgtrt/src/routes/openai.rs
@@ -178,12 +178,15 @@ pub struct CommonCreateParams {
     pub priority: Option<f32>,
 
     /// The uint64 unique ID of the LoRA weights to apply.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lora_id: Option<u64>,
+    //#[serde(skip_serializing_if = "Option::is_none")]
+    //pub lora_id: Option<u64>,
 
-    /// Name of the directory containing LoRA weights (weights and config)
+    /// LoRA model name
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lora_dir: Option<String>,
+    pub lora_model: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_load_lora_cache: Option<bool>,
 }
 
 #[derive(Serialize, Debug)]

--- a/llgtrt/src/routes/openai.rs
+++ b/llgtrt/src/routes/openai.rs
@@ -62,6 +62,23 @@ pub enum ToolChoiceOption {
     Required,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LoadLoraWeightsOption {
+    /// Automatically load the LoRA cache for new LoRA weights or cache misses.
+    Auto,
+    /// Never load the LoRA cache; propagate cache miss errors to the caller.
+    Never,
+    /// Always load LoRA weights regardless of the state of the cache.
+    Always,
+}
+
+impl Default for LoadLoraWeightsOption {
+    fn default() -> Self {
+        LoadLoraWeightsOption::Auto
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Tool {
@@ -177,16 +194,12 @@ pub struct CommonCreateParams {
     #[serde(skip)]
     pub priority: Option<f32>,
 
-    /// The uint64 unique ID of the LoRA weights to apply.
-    //#[serde(skip_serializing_if = "Option::is_none")]
-    //pub lora_id: Option<u64>,
-
     /// LoRA model name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lora_model: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_load_lora_cache: Option<bool>,
+    #[serde(default)]
+    pub load_lora_weights: LoadLoraWeightsOption,
 }
 
 #[derive(Serialize, Debug)]

--- a/llgtrt/src/routes/openai.rs
+++ b/llgtrt/src/routes/openai.rs
@@ -176,6 +176,14 @@ pub struct CommonCreateParams {
     /// Setting to higher value like 1.0 or 10.0 will make the request complete faster.
     #[serde(skip)]
     pub priority: Option<f32>,
+
+    /// The uint64 unique ID of the LoRA weights to apply.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lora_id: Option<u64>,
+
+    /// Name of the directory containing LoRA weights (weights and config)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lora_dir: Option<String>,
 }
 
 #[derive(Serialize, Debug)]

--- a/llgtrt/src/startup.rs
+++ b/llgtrt/src/startup.rs
@@ -195,7 +195,7 @@ pub async fn run_server(mut cli_config: CliConfig) -> anyhow::Result<()> {
         state.tokenize_with_bos("The ultimate answer to life, the universe and everything is");
     log::debug!("Warmup tokens: {:?}", warmup_tokens);
     let (_, mut rx) = AsyncExecutor::lock().add_request(
-        RequestInit {
+        &RequestInit {
             tokens: warmup_tokens.clone(),
             params: RequestParams {
                 max_new_tokens: 10,

--- a/llgtrt/src/startup.rs
+++ b/llgtrt/src/startup.rs
@@ -199,6 +199,7 @@ pub async fn run_server(mut cli_config: CliConfig) -> anyhow::Result<()> {
                 ..Default::default()
             },
             client_req_id: ClientReqId::new(1),
+            lora_params: None,
             is_run: false,
         },
         vec![],

--- a/llgtrt/src/startup.rs
+++ b/llgtrt/src/startup.rs
@@ -17,6 +17,7 @@ use crate::config::{config_info, CliConfig, LlgTrtConfig};
 use crate::jsonutil::json5_to_string;
 use crate::state::AppState;
 use crate::{jsonutil, routes};
+use crate::lora::LoraCache;
 
 async fn auth_middleware(
     req: Request<Body>,
@@ -185,6 +186,7 @@ pub async fn run_server(mut cli_config: CliConfig) -> anyhow::Result<()> {
         chat_builder,
         parser_factory,
         lora_root: cli_config.lora_root,
+        lora_cache: LoraCache::new(),
     };
 
     // warmup request

--- a/llgtrt/src/startup.rs
+++ b/llgtrt/src/startup.rs
@@ -184,6 +184,7 @@ pub async fn run_server(mut cli_config: CliConfig) -> anyhow::Result<()> {
         next_client_req_id: std::sync::atomic::AtomicUsize::new(1000),
         chat_builder,
         parser_factory,
+        lora_root: cli_config.lora_root,
     };
 
     // warmup request

--- a/llgtrt/src/state.rs
+++ b/llgtrt/src/state.rs
@@ -12,6 +12,7 @@ pub struct AppState {
     pub next_client_req_id: std::sync::atomic::AtomicUsize,
     pub chat_builder: ChatBuilder,
     pub parser_factory: ParserFactory,
+    pub lora_root: Option<String>,
 }
 
 impl AppState {

--- a/llgtrt/src/state.rs
+++ b/llgtrt/src/state.rs
@@ -1,4 +1,5 @@
 use crate::chat::ChatBuilder;
+use crate::lora::LoraCache;
 use llguidance::ParserFactory;
 use toktrie::{TokEnv, TokenId};
 
@@ -13,6 +14,7 @@ pub struct AppState {
     pub chat_builder: ChatBuilder,
     pub parser_factory: ParserFactory,
     pub lora_root: Option<String>,
+    pub lora_cache: LoraCache,
 }
 
 impl AppState {

--- a/scripts/extract_lora.py
+++ b/scripts/extract_lora.py
@@ -1,0 +1,185 @@
+#! /usr/bin/env python3
+import argparse
+import datetime
+import json
+import logging
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import torch
+import safetensors
+
+from tensorrt_llm.lora_manager import LoraManager
+from tensorrt_llm.models.convert_utils import get_model_path, load_state_dict
+
+log_format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
+logging.basicConfig(format=log_format)
+LOGGER = logging.getLogger(__name__)
+
+def get_all_lora_weights(lora_weights):
+    all_weights = defaultdict(lambda: defaultdict(dict))
+    pattern = re.compile(
+        r'.*\.layers\.([0-9]+)\.(self_attn|mlp)\.([a-z_]+)\.lora_(A|B)\.weight.*'
+    )
+    moe_pattern = re.compile(
+        r'.*\.layers\.([0-9]+)\.(block_sparse_moe)\.((experts)\.([0-9]+)\.|)([a-zA-Z0-9_]+)\.lora_(A|B)\.weight.*'
+    )
+    for key, weights in lora_weights.items():
+        m = pattern.match(key)
+        m_moe = moe_pattern.match(key)
+        if m:
+            layer_idx = int(m.group(1))
+            hf_module = m.group(3)
+            inout = "in" if m.group(4) == "A" else "out"
+            all_weights[layer_idx][hf_module][inout] = weights
+        elif m_moe:
+            layer_idx = int(m_moe.group(1))
+            hf_module = m_moe.group(6)
+            inout = "in" if m_moe.group(7) == "A" else "out"
+            all_weights[layer_idx][hf_module][inout] = weights
+        else:
+            print(f"no match {key}")
+            continue
+    return all_weights
+
+
+def preprocess_lora_weights(lora_model):
+    # Swap weights of gate_up_proj
+    for key, value in lora_model.items():
+        if "gate_up_proj.lora_B.weight" in key:
+            print("Swap {}".format(key))
+            original_weights = value.contiguous().clone()
+            half_split = original_weights.shape[0] // 2
+            first_half = original_weights[:half_split, :]
+            second_half = original_weights[half_split:, :]
+            value = torch.cat((second_half, first_half), dim=0)
+            lora_model[key] = value
+    return lora_model
+
+
+hf_modules_to_trtllm_modules = {
+    "q_proj": "attn_q",
+    "v_proj": "attn_v",
+    "k_proj": "attn_k",
+    "qkv_proj": "attn_qkv",
+    "query_key_value": "attn_qkv",
+    "o_proj": "attn_dense",
+    "dense": "attn_dense",
+    "gate_proj": "mlp_h_to_4h",
+    "down_proj": "mlp_4h_to_h",
+    "up_proj": "mlp_gate",
+    "gate_up_proj": "mlp_h_to_4h",
+    "c_fc": "mlp_h_to_4h",
+    "c_proj": "mlp_4h_to_h",
+    "w1": "moe_h_to_4h",
+    "w2": "moe_4h_to_h",
+    "w3": "moe_gate",
+    "gate": "moe_router",
+}  # lora modules on llama
+hf_modules_to_module_id = {
+    k: LoraManager.LORA_MODULE_IDS[v]
+    for k, v in hf_modules_to_trtllm_modules.items()
+}
+
+
+def convert_hf_model(model_dir, out_file):
+    with open(f"{model_dir}/adapter_config.json", "r") as f:
+        config = json.load(f)
+
+    alpha = config.get("lora_alpha")
+    use_rslora = config.get("use_rslora", False)
+
+    lora_model = load_state_dict(get_model_path(model_dir, "adapter_model"))
+    lora_model = preprocess_lora_weights(lora_model)
+    all_weights = get_all_lora_weights(lora_model)
+    converted_weights = []
+    converted_config = []
+    for layer_idx, layer_weights in all_weights.items():
+        for hf_module, module_weights in layer_weights.items():
+            in_weights = module_weights['in']
+            out_weights = module_weights['out']
+            in_out_weights = []
+            adapter_size = 0
+            for w, inout in ((in_weights, "in"), (out_weights, "out")):
+                assert len(w.shape) == 2
+                # assume that the hidden dim is the larger of the 2
+                dim0 = w.shape[0]
+                dim1 = w.shape[1]
+                adapter_size = min(dim0, dim1)
+                # in_weights should have shape [adaper_size, hidden]
+                if dim1 < dim0 and inout == "in":
+                    adapter_size = dim1
+                    w = w.transpose(1, 0)
+                # out_weights should have shape [hidden, adapter_size]
+                elif dim0 < dim1 and inout == "out":
+                    adapter_size = dim0
+                    w = w.transpose(1, 0)
+                if inout == "out":
+                    if use_rslora:
+                        scale = alpha / np.sqrt(adapter_size)
+                    else:
+                        scale = alpha / adapter_size
+                    w = w * scale
+                w = w.contiguous().flatten()
+                in_out_weights.append(w)
+            in_out_weights = torch.concatenate(in_out_weights).flatten()
+            converted_weights.append(in_out_weights)
+            converted_config.append(
+                [hf_modules_to_module_id[hf_module], layer_idx, adapter_size])
+    max_row_size = 0
+    for t in converted_weights:
+        max_row_size = max(max_row_size, t.shape[0])
+    for i in range(len(converted_weights)):
+        converted_weights[i] = torch.nn.functional.pad(
+            converted_weights[i],
+            (0, max_row_size - converted_weights[i].shape[0]))
+    converted_weights = torch.concatenate(
+            converted_weights,
+            dim=0).unsqueeze(0).cpu()
+    converted_config = torch.tensor(converted_config,
+                                    dtype=torch.int32,
+                                    device='cpu')
+    output_dict = {
+        'weights': converted_weights,
+        'config': converted_config
+    }
+
+    safetensors.torch.save_file(output_dict, out_file)
+
+
+def main(args):
+    start_time = datetime.datetime.now()
+    convert_hf_model(args.in_file, args.out_file)
+
+    LOGGER.info("Spent %s (h:m:s) to convert the prompt model",
+                datetime.datetime.now() - start_time)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--out-file',
+        '-o',
+        type=Path,
+        help='path to output extracted LoRA weights and config in safetensors format',
+        required=True)
+    parser.add_argument('--in-file',
+                        '-i',
+                        type=Path,
+                        help='path to input lora checkpoint file',
+                        required=True)
+    parser.add_argument("--verbose",
+                        action="store_true",
+                        help="Provide verbose messages")
+    args = parser.parse_args()
+
+    LOGGER.setLevel(logging.DEBUG if args.verbose else logging.INFO)
+
+    print("\n=============== Argument ===============")
+    for key in vars(args):
+        print(f"{key}: {vars(args)[key]}")
+    print("========================================")
+
+    main(args)

--- a/trtllm-c/tlc.h
+++ b/trtllm-c/tlc.h
@@ -88,6 +88,24 @@ extern "C"
         TlcEngineParams engine_params;
     } TlcInitParams;
 
+    // TensorRT tensor class support
+    typedef struct {
+        const int64_t* dims_ptr;
+        size_t num_dims;
+    } TlcShape;
+
+    typedef struct {
+        int32_t data_type;
+        const void *data_ptr;
+        TlcShape shape;
+    } TlcTensor;
+
+    typedef struct {
+        uint64_t lora_id;
+        TlcTensor weights;
+        TlcTensor config;
+    } TlcLoraParams;
+
     typedef struct
     {
         bool use_logits_post_processor;
@@ -112,6 +130,7 @@ extern "C"
         uint32_t num_tokens;
         TlcClientId client_req_id;
         TlcRequestParams params;
+        TlcLoraParams lora_params;
     } TlcRequest;
 
     /// @brief The reason why the model stopped generating tokens for a request.

--- a/trtllm_rs/Cargo.toml
+++ b/trtllm_rs/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 anyhow = "1.0.89"
 libc = "0.2.158"
 serde = { version = "1.0.210", features = ["derive"] }
+ndarray = "0.16.1"
+half = "2.4.1"
 
 [build-dependencies]
 bindgen = "*"

--- a/trtllm_rs/Cargo.toml
+++ b/trtllm_rs/Cargo.toml
@@ -9,6 +9,7 @@ libc = "0.2.158"
 serde = { version = "1.0.210", features = ["derive"] }
 ndarray = "0.16.1"
 half = "2.4.1"
+safetensors = "0.5.2"
 
 [build-dependencies]
 bindgen = "*"

--- a/trtllm_rs/Cargo.toml
+++ b/trtllm_rs/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 anyhow = "1.0.89"
 libc = "0.2.158"
 serde = { version = "1.0.210", features = ["derive"] }
-ndarray = "0.16.1"
-half = "2.4.1"
 safetensors = "0.5.2"
 
 [build-dependencies]


### PR DESCRIPTION
This change adds support for LoRA finetuning to llgtrt.

This implementation of LoRA support stays close to the support already provided by TensorRT.  It can be activated by adding two parameters to your inference requests:

_lora_id_: unsigned integer identifier for the set of LoRA weights.  If the set of weights is already present in this TensorRT instance's cache then providing this Id is enough.  If not then you must also specify _lora_dir_.

_lora_dir_: name of the LoRA subdirectory that contains the weights.  You must also provide _lora_dir_ when using this parameter.  Use of _lora_dir_ has the side effect of loading this set of weights into this TensorRT instance's cache, keyed by the provided _lora_id_.  If the cache fills up then TensorRT may evict another set of weights.
