### PR TITLE
Add min_p sampling support

### DIFF
--- a/llgtrt/src/async_exec.rs
+++ b/llgtrt/src/async_exec.rs
@@ -436,7 +436,6 @@ impl AsyncExecutor {
         &mut self,
         init: &RequestInit,
         llgs: Vec<Box<Constraint>>,
-        min_p: f32,
     ) -> Result<(ReqId, UnboundedReceiver<StepResults>)> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
@@ -458,7 +457,7 @@ impl AsyncExecutor {
                 llgs: llgs.into_iter().map(Some).collect(),
                 llg_infos: vec![],
                 prompt_len,
-                min_p,
+                min_p: init.params.min_p,
                 logs: String::new(),
                 is_run,
             },

--- a/llgtrt/src/routes/completions.rs
+++ b/llgtrt/src/routes/completions.rs
@@ -103,6 +103,7 @@ fn req_params_from_openai(params: &CommonCreateParams) -> Result<RequestParams> 
     let mut r = RequestParams {
         temperature: params.temperature,
         top_p: params.top_p,
+        min_p: params.min_p,
         max_new_tokens: params
             .max_completion_tokens
             .unwrap_or_else(|| params.max_tokens.unwrap_or(16)) as u32,
@@ -286,7 +287,7 @@ fn llg_grammar(params: &CommonCreateParams) -> Result<Option<TopLevelGrammar>> {
             if params.min_p > 0.0 {
                 // Returning a Dummy-grammar to enforce logit processing when min_p is set
                 let grm = TopLevelGrammar::from_regex(llguidance::api::RegexNode::Regex(
-                    ".*".to_string(),
+                    r"(\n|.)*".to_string(),
                 ));
                 return Ok(Some(grm));
             }
@@ -476,7 +477,7 @@ async fn mk_req_info(
     )?;
     let prompt_tokens = req_init.tokens.len();
 
-    let (req_id, recv) = AsyncExecutor::lock().add_request(&req_init, llg.clone(), params.min_p)?;
+    let (req_id, recv) = AsyncExecutor::lock().add_request(&req_init, llg.clone())?;
 
     let info = build_req_info(
         req_id,
@@ -513,7 +514,7 @@ async fn mk_req_info(
                     let prompt_tokens = req_init.tokens.len();
 
                     let (req_id, recv) =
-                        AsyncExecutor::lock().add_request(&req_init, llg.clone(), params.min_p)?;
+                        AsyncExecutor::lock().add_request(&req_init, llg.clone())?;
 
                     let info = build_req_info(
                         req_id,

--- a/llgtrt/src/routes/openai.rs
+++ b/llgtrt/src/routes/openai.rs
@@ -1,7 +1,7 @@
 use super::api_ext::LlgLogLevel;
 use llguidance::api::TopLevelGrammar;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, f32};
 use toktrie::{TokTrie, TokenId};
 
 // https://platform.openai.com/docs/api-reference/chat/create
@@ -165,6 +165,9 @@ pub struct CommonCreateParams {
     /// tokens comprising the top 10% probability mass are considered.
     #[serde(default = "default_top_p")]
     pub top_p: f32,
+    /// Filters out tokens with probability less than min_p multiplied by the probability of the most likely token
+    #[serde(default = "default_min_p")]
+    pub min_p: f32,
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect
     /// abuse.
     #[allow(dead_code)]
@@ -256,6 +259,10 @@ fn default_top_p() -> f32 {
 
 fn default_min_tokens() -> usize {
     1
+}
+
+fn default_min_p() -> f32 {
+    0.0
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/llgtrt/src/routes/openai.rs
+++ b/llgtrt/src/routes/openai.rs
@@ -1,7 +1,7 @@
 use super::api_ext::LlgLogLevel;
 use llguidance::api::TopLevelGrammar;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{collections::HashMap, f32};
+use std::collections::HashMap;
 use toktrie::{TokTrie, TokenId};
 
 // https://platform.openai.com/docs/api-reference/chat/create
@@ -166,7 +166,7 @@ pub struct CommonCreateParams {
     #[serde(default = "default_top_p")]
     pub top_p: f32,
     /// Filters out tokens with probability less than min_p multiplied by the probability of the most likely token
-    #[serde(default = "default_min_p")]
+    #[serde(default)]
     pub min_p: f32,
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect
     /// abuse.
@@ -259,10 +259,6 @@ fn default_top_p() -> f32 {
 
 fn default_min_tokens() -> usize {
     1
-}
-
-fn default_min_p() -> f32 {
-    0.0
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/llgtrt/src/startup.rs
+++ b/llgtrt/src/startup.rs
@@ -206,6 +206,7 @@ pub async fn run_server(mut cli_config: CliConfig) -> anyhow::Result<()> {
             is_run: false,
         },
         vec![],
+        0.0,
     )?;
     while let Some(r) = rx.recv().await {
         warmup_tokens.extend_from_slice(&r.response.tokens);

--- a/llgtrt/src/startup.rs
+++ b/llgtrt/src/startup.rs
@@ -206,7 +206,6 @@ pub async fn run_server(mut cli_config: CliConfig) -> anyhow::Result<()> {
             is_run: false,
         },
         vec![],
-        0.0,
     )?;
     while let Some(r) = rx.recv().await {
         warmup_tokens.extend_from_slice(&r.response.tokens);

--- a/trtllm-c/logits.cpp
+++ b/trtllm-c/logits.cpp
@@ -1,3 +1,4 @@
+#include <cfloat>
 #include <stdexcept>
 #include <string>
 #include <cmath>
@@ -34,7 +35,7 @@ void* tlc_alloc_logit_data(int32_t mask_stride_, int32_t max_batch_size_)
     assert(max_batch_size > 0);
     assert(mask_stride % 4 == 0);
 
-    size_t hd_size = max_batch_size * sizeof(int64_t) * 4;
+    size_t hd_size = max_batch_size * sizeof(int64_t) * 5;
     size_t sz2 = hd_size + max_batch_size * mask_stride;
     masks_size = sz2;
     if (cudaHostAlloc(&masksData, sz2, cudaHostAllocDefault))
@@ -46,7 +47,7 @@ void* tlc_alloc_logit_data(int32_t mask_stride_, int32_t max_batch_size_)
 
 float* tlc_mask_fraction_ptr()
 {
-    return (float*) ((uint8_t*) masksData + max_batch_size * sizeof(int64_t) * 3);
+    return (float*) ((uint8_t*) masksData + max_batch_size * sizeof(int64_t) * 4);
 }
 
 #define MAX_BATCH_SIZE 128
@@ -109,6 +110,7 @@ static void logitsPostProcessorFn(std::vector<tle::IdType> const& reqIds, std::v
         entry._num_tokens = tokens[i].get()[0].size();
         entry.out_mask_pointer = nullptr;
         entry.temperature = 1.0f;
+        entry.ln_min_p = -FLT_MAX;
         entries.push_back(entry);
 
         // auto shape = logits[i].getShape();
@@ -130,8 +132,10 @@ static void logitsPostProcessorFn(std::vector<tle::IdType> const& reqIds, std::v
     int64_t* logitPtrs = (int64_t*) masksData;
     int64_t* masksOffsets = logitPtrs + batchSize;
     float* temperatures = (float*) (logitPtrs + 2 * batchSize);
+    float* lnMinPs = (float*) (logitPtrs + 3 * batchSize);
 
     int64_t temperatures_offset = (uint8_t*) temperatures - (uint8_t*) masksData;
+    int64_t ln_min_p_offset = (uint8_t*) lnMinPs - (uint8_t*) masksData;
     int64_t mask_fractions_offset = (uint8_t*) tlc_mask_fraction_ptr() - (uint8_t*) masksData;
 
     int64_t* cudaLogitPtrs = (int64_t*) cudaMasksData;
@@ -187,6 +191,8 @@ static void logitsPostProcessorFn(std::vector<tle::IdType> const& reqIds, std::v
 
         masksOffsets[dp] = mask_offset;
         temperatures[dp] = entries[i].temperature;
+        lnMinPs[dp] = entries[i].ln_min_p;
+
 
         if (mask_offset > max_offset)
             max_offset = mask_offset;
@@ -201,8 +207,8 @@ static void logitsPostProcessorFn(std::vector<tle::IdType> const& reqIds, std::v
     if (dp > 0)
     {
         cudaMemcpyAsync(cudaMasksData, masksData, max_offset + mask_stride, cudaMemcpyHostToDevice, stream);
-        mask_logits_ext(cudaLogitPtrs, cudaMasksOffsets, mask_fractions_offset, temperatures_offset, dp, nVocab,
-            mask_stride / 4, tp, stream);
+        mask_logits_ext(cudaLogitPtrs, cudaMasksOffsets, mask_fractions_offset, temperatures_offset, ln_min_p_offset,
+            dp, nVocab, mask_stride / 4, tp, stream);
         cudaMemcpyAsync((uint8_t*) masksData + mask_fractions_offset, (uint8_t*) cudaMasksData + mask_fractions_offset,
             dp * sizeof(float), cudaMemcpyDeviceToHost, stream);
 

--- a/trtllm-c/mask_logits.h
+++ b/trtllm-c/mask_logits.h
@@ -10,6 +10,7 @@ void mask_logits_ext(int64_t* d_logit_ptrs, // in,out [batch_size]
     int64_t* d_mask_offsets,                // in [int32_t,mask_stride], [batch_size]
     int64_t mask_fractions_offset,          // out, float, [batch_size]
     int64_t temperature_offset,             // in, float, [batch_size]; can be 0.0f for argmax
+    int64_t ln_min_p_offset,                // in, float, [batch_size]; log_e(min_p) for min_p > 0.0f, -FLT_MAX otherwise
     size_t batch_size,                      // current batch size
     size_t n_vocab,                         // vocab size
     size_t mask_stride,                     // n_vocab / 32 or thereabouts

--- a/trtllm-c/tlc.h
+++ b/trtllm-c/tlc.h
@@ -118,6 +118,7 @@ extern "C"
         uint32_t eos_token_id;
         float temperature;
         float top_p;
+        float min_p;
         float frequency_penalty;
         float presence_penalty;
         float priority;

--- a/trtllm-c/tlc.h
+++ b/trtllm-c/tlc.h
@@ -23,6 +23,8 @@ extern "C"
         uint32_t _num_tokens;
         // set by the callback (initially 1.0)
         float temperature;
+        // set by the callback (initially -FLT_MAX)
+        float ln_min_p;
         // set by the callback (initially NULL)
         uint32_t* out_mask_pointer;
     } TlcLogitsEntry;

--- a/trtllm_rs/src/tlc.rs
+++ b/trtllm_rs/src/tlc.rs
@@ -55,6 +55,7 @@ impl Default for RequestParams {
             num_return_sequences: 1,
             temperature: f32::NAN,
             top_p: 1.0,
+            min_p: 0.0,
             presence_penalty: 0.0,
             frequency_penalty: 0.0,
             top_k: 0,


### PR DESCRIPTION
This PR adds support for min_p sampling, which helps control token sampling diversity 
by filtering out tokens with probabilities below min_p multiplied with the probability of the most likely token. 
This feature is useful for improving text coherence while maintaining some randomness, 
particularly in long-context chatting scenarios with smaller models.

Related issue: #4

Key changes:
1. API integration:
- Add `min_p` parameter to completions API endpoint (defaults to 0.0)
- Create dummy `".*"` regex grammar when `min_p > 0.0` to ensure logit processing
- Pass `min_p` through `AsyncExecutor::add_request()`
- Calculate `ln(min_p)` in `PendingSeq::step()` for active requests

2. Core sampling implementation:
- Add `ln_min_p` field to `TlcLogitsEntry` struct (initialized to `-FLT_MAX`)
- Extend CUDA kernel to filter tokens below `ln_min_p` threshold using `logit_adjusted` comparison
- Adjusted host memory allocation to accommodate `ln_min_p` values

Please let me know if there are any changes necessary to approve this PR.